### PR TITLE
Add dark mode support

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -1,3 +1,28 @@
+:root {
+	--bg-color: #ffffff;
+	--text-color: #000000;
+	--input-bg: #ffffff;
+	--input-border: #cccccc;
+	--hover-bg: #90ee90;
+	--selected-bg: #ffff00;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--bg-color: #1e1e1e;
+		--text-color: #e0e0e0;
+		--input-bg: #2d2d2d;
+		--input-border: #555555;
+		--hover-bg: #2e7d32;
+		--selected-bg: #b8860b;
+	}
+}
+
+body {
+	background-color: var(--bg-color);
+	color: var(--text-color);
+}
+
 .popup-page {
 	font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 	font-weight: bold;
@@ -6,14 +31,21 @@
 	padding: 30px;
 }
 
+input[type="text"] {
+	background-color: var(--input-bg);
+	color: var(--text-color);
+	border: 1px solid var(--input-border);
+	padding: 4px 8px;
+}
+
 li {
 	cursor: pointer;
 }
 
 li:hover {
-	background-color: #00ff00
+	background-color: var(--hover-bg);
 }
 
 .selected {
-	background-color: #ffff00
+	background-color: var(--selected-bg);
 }


### PR DESCRIPTION
## Summary
- Add dark mode support to popup styling using CSS custom properties and `prefers-color-scheme` media query
- Colors automatically adapt based on system theme preference

## Test plan
- [ ] Load extension in Thunderbird with light mode system theme, verify popup has light background and readable colors
- [ ] Switch system to dark mode, verify popup adapts with dark background and appropriate contrast
- [ ] Test hover and selected states in both modes